### PR TITLE
Results button and image count 

### DIFF
--- a/src/components/Results/Results.js
+++ b/src/components/Results/Results.js
@@ -52,7 +52,7 @@ const Results = props => {
                 <Title>{resultsLoadingText}</Title>
               )}
               <Image counter={counter} />
-              {results.length > 0 ? (
+              {results.length > 0 && results.length > 12 ? (
                 <StyledButton
                   primary
                   onClick={() =>


### PR DESCRIPTION
Made changes to how search results were shown: 

- Results images counter now shows the amount of available images if that amount is less than 12, as opposed to showing 12 for each valid search query.

- More Images button only gets rendered if there are more than 12 results 