### PR TITLE
Show correct number of images that contain less than 12

### DIFF
--- a/src/components/Results/Results.js
+++ b/src/components/Results/Results.js
@@ -34,8 +34,9 @@ const Results = props => {
   const { counter, setCounter } = props;
 
   const findImages = (search, images) => {
+    const initialCount = images.length >= 12 ? counter : images.length;
     if (images.length > 0) {
-      return `Results for "${search}" (${counter}/${images.length} images)`;
+      return `Results for "${search}" (${initialCount}/${images.length} images)`;
     }
     return `No images found for "${search}"`;
   };

--- a/src/components/Results/Results.js
+++ b/src/components/Results/Results.js
@@ -52,7 +52,7 @@ const Results = props => {
                 <Title>{resultsLoadingText}</Title>
               )}
               <Image counter={counter} />
-              {results.length > 0 ? (
+              {results.length > 0 && results.length > 12 ? (
                 <StyledButton
                   primary
                   onClick={() =>


### PR DESCRIPTION
Shows the correct number of available images for search queries that return less than 12 images. Previously, it would always show 12 in the image counter text (ex. 12/5). 